### PR TITLE
chore: updated clock.js to remove dependency on Node intl full-icu

### DIFF
--- a/app/newTab/clock.js
+++ b/app/newTab/clock.js
@@ -19,7 +19,7 @@
   Clock.prototype.getNewDate = function() {
     let date = new Date();
     let options = { weekday: "long", year: "numeric", month: "long", day: "numeric"}
-    return date.toLocaleDateString('en-GB', options);
+    return date.toLocaleDateString("en", options);
   }
 
   exports.Clock = Clock;


### PR DESCRIPTION
Hi,

To resolve conflicts in printing the date string, I've removed the GB flag for date. This is perhaps not ideal, but doesn't require us to rebuild Node with the Intl with the full-ICU library.

So date displayed changes from "Thursday, 25 October 2018" to "Thursday, October 25, 2018"

Hope this is ok?